### PR TITLE
Use @include_once to load plugins composers dependencies.

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  * @author DGTL.ONE
  */
 
-require_once __DIR__ . '/vendor/autoload.php';
+@include_once __DIR__ . '/vendor/autoload.php';
 load(['DGTLONE\Chunky' => __DIR__ . '/lib/chunky.php']);
 
 Kirby::plugin('dgtlone/kirby-chunky', [


### PR DESCRIPTION
Closes #2

When installing Kirby with composer `getkirby/composer-installer` takes care of installing the plugins composer dependencies into the _main_ composer vendor directory. 

You can the check the [the Kirby Plugin guide](https://getkirby.com/docs/guide/plugins/plugin-setup-composer#support-for-plugin-installation-without-composer) for further information on how to setup the plugin to support different installation methods.

> Note that you should _not_ `require` the autoloader, as it will only be present if the plugin is installed manually or via a Git submodule. Our custom Composer installer will delete the `vendor` directories from plugins to avoid code duplication and autoloading issues. By using `@include_once`, you tell PHP to load the file only if it exists.